### PR TITLE
Fix: Support for react native 0.81 on Android

### DIFF
--- a/android/src/main/java/com/multiplemodals/RNTModalViewManager.kt
+++ b/android/src/main/java/com/multiplemodals/RNTModalViewManager.kt
@@ -22,9 +22,14 @@ class RNTModalViewManager : RNTModalViewManagerSpec<RNTModalView>() {
   override fun getExportedCustomDirectEventTypeConstants(): MutableMap<String, Any> {
     val buildOf = "registrationName"
 
-    return MapBuilder.builder<String, Any>()
+    val map = MapBuilder.builder<String, Any>()
       .put(PressBackEvent.NAME, MapBuilder.of(buildOf, PressBackEvent.REGISTRATION_NAME))
       .build()
+    
+    return when (map) {
+      is MutableMap<String, Any> -> map
+      else -> map.toMutableMap()
+    }
   }
 
   override fun onDropViewInstance(view: RNTModalView) {

--- a/android/src/main/jni/CMakeLists.txt
+++ b/android/src/main/jni/CMakeLists.txt
@@ -74,15 +74,19 @@ else()
   )
 endif()
 
-target_compile_options(
-  ${LIB_TARGET_NAME}
-  PRIVATE
-  -DLOG_TAG=\"ReactNative\"
-  -fexceptions
-  -frtti
-  -std=c++20
-  -Wall
-)
+if(ReactAndroid_VERSION_MINOR GREATER_EQUAL 81)
+  target_compile_reactnative_options(${LIB_TARGET_NAME} PRIVATE)
+else()
+  target_compile_options(
+    ${LIB_TARGET_NAME}
+    PRIVATE
+    -DLOG_TAG=\"ReactNative\"
+    -fexceptions
+    -frtti
+    -std=c++20
+    -Wall
+  )
+endif()
 
 target_include_directories(
  ${CMAKE_PROJECT_NAME}


### PR DESCRIPTION
This PR addresses two key compatibility issues introduced in React Native 0.81+:

1. **Return Type Change in `getExportedCustomDirectEventTypeConstants()`**:
   - React Native 0.81 updated the expected return type from `Map<String, Any>` to `MutableMap<String, Any>`.
   - This change implements safe casting using a `when` expression to check if the map is already mutable, converting to `MutableMap` only when necessary.
   - Ensures full compatibility across all RN versions without breaking older ones.

2. **Runtime Crashes on Android Due to New Architecture Changes**:
   - RN 0.81 introduced the `RN_SERIALIZABLE_STATE` macro for serializable state in the New Architecture, requiring updates to custom CMakeLists.txt files.
   - Added `target_compile_reactnative_options` to the library's CMakeLists.txt to automatically set up the macro and necessary C++ flags.
   - Resolves runtime crashes on Android while maintaining compatibility with older RN versions.