### PR TITLE
Make the React Native inspector work in Modals

### DIFF
--- a/global.d.ts
+++ b/global.d.ts
@@ -8,3 +8,8 @@ declare module 'react-native/Libraries/Components/ScrollView/ScrollViewContext' 
   const ScrollViewContext: any;
   export default ScrollViewContext;
 }
+
+declare module 'react-native/Libraries/ReactNative/AppContainer' {
+  const AppContainer: any;
+  export default AppContainer;
+}

--- a/src/AppContainerWrapper.tsx
+++ b/src/AppContainerWrapper.tsx
@@ -1,0 +1,18 @@
+import { FC, PropsWithChildren, useContext } from 'react';
+
+import AppContainer from 'react-native/Libraries/ReactNative/AppContainer';
+import { RootTagContext } from 'react-native/Libraries/ReactNative/RootTag';
+
+// Wrap the children in AppContainer so the React Native inspector works
+// within the modal. See https://github.com/facebook/react-native/blob/v0.81.4/packages/react-native/Libraries/Modal/Modal.js#L308
+// for the inspiration within the RN Modal component.
+export const AppContainerWrapper: FC<PropsWithChildren> = ({ children }) => {
+  const rootTag = useContext(RootTagContext);
+
+  // The inspector is only needed in development
+  if (!__DEV__) {
+    return children;
+  }
+
+  return <AppContainer rootTag={rootTag}>{children}</AppContainer>;
+};

--- a/src/ModalView.tsx
+++ b/src/ModalView.tsx
@@ -1,6 +1,8 @@
-import { FC } from 'react';
+import { FC, useContext } from 'react';
 
 import { Platform, Pressable, StatusBar, StyleSheet, View } from 'react-native';
+import AppContainer from 'react-native/Libraries/ReactNative/AppContainer';
+import { RootTagContext } from 'react-native/Libraries/ReactNative/RootTag';
 
 import { ScrollContextResetter } from './ScrollContextResetter';
 import { GestureHandlerRootView } from './integrations/GestureHandlerRootView';
@@ -29,6 +31,17 @@ export const ModalView: FC<ModalViewProps> = ({
   animationType = 'none',
   statusBarTranslucent,
 }) => {
+  const rootTag = useContext(RootTagContext);
+
+  // Wrap the children in AppContainer so the React Native inspector works
+  // within the modal. See https://github.com/facebook/react-native/blob/v0.81.4/packages/react-native/Libraries/Modal/Modal.js#L308
+  // for the inspiration within the RN Modal component.
+  const innerChildren = __DEV__ ? (
+    <AppContainer rootTag={rootTag}>{children}</AppContainer>
+  ) : (
+    children
+  );
+
   return (
     <RNTModalView
       style={styles.container}
@@ -63,7 +76,7 @@ export const ModalView: FC<ModalViewProps> = ({
               pointerEvents='box-none'
               style={[styles.content, contentContainerStyle]}
             >
-              {children}
+              {innerChildren}
             </View>
           </ScrollContextResetter>
         </GestureHandlerRootView>

--- a/src/ModalView.tsx
+++ b/src/ModalView.tsx
@@ -1,9 +1,8 @@
-import { FC, useContext } from 'react';
+import { FC } from 'react';
 
 import { Platform, Pressable, StatusBar, StyleSheet, View } from 'react-native';
-import AppContainer from 'react-native/Libraries/ReactNative/AppContainer';
-import { RootTagContext } from 'react-native/Libraries/ReactNative/RootTag';
 
+import { AppContainerWrapper } from './AppContainerWrapper';
 import { ScrollContextResetter } from './ScrollContextResetter';
 import { GestureHandlerRootView } from './integrations/GestureHandlerRootView';
 import RNTModalView from './newarch/NativeRNTModalView';
@@ -31,17 +30,6 @@ export const ModalView: FC<ModalViewProps> = ({
   animationType = 'none',
   statusBarTranslucent,
 }) => {
-  const rootTag = useContext(RootTagContext);
-
-  // Wrap the children in AppContainer so the React Native inspector works
-  // within the modal. See https://github.com/facebook/react-native/blob/v0.81.4/packages/react-native/Libraries/Modal/Modal.js#L308
-  // for the inspiration within the RN Modal component.
-  const innerChildren = __DEV__ ? (
-    <AppContainer rootTag={rootTag}>{children}</AppContainer>
-  ) : (
-    children
-  );
-
   return (
     <RNTModalView
       style={styles.container}
@@ -50,37 +38,39 @@ export const ModalView: FC<ModalViewProps> = ({
       onPressBackAndroid={() => onRequestDismiss?.(DismissalSource.BackButton)}
       animationType={animationType}
     >
-      <View collapsable={false} style={styles.flex}>
-        {isIOS && statusBar && !disableDefaultStatusBarIOS ? (
-          <StatusBar {...statusBar} />
-        ) : null}
-        <GestureHandlerRootView style={styles.flex}>
-          <View style={[styles.backdropContainer]}>
-            <BackdropPressableComponent
-              accessibilityLabel={backdropAccessibilityLabel}
-              accessibilityHint={backdropAccessibilityHint}
-              style={styles.flex}
-              onPress={() => onRequestDismiss?.(DismissalSource.Backdrop)}
-            >
-              {renderBackdrop ? (
-                renderBackdrop()
-              ) : (
-                <View
-                  style={[styles.flex, { backgroundColor: backdropColor }]}
-                />
-              )}
-            </BackdropPressableComponent>
-          </View>
-          <ScrollContextResetter>
-            <View
-              pointerEvents='box-none'
-              style={[styles.content, contentContainerStyle]}
-            >
-              {innerChildren}
+      <AppContainerWrapper>
+        <View collapsable={false} style={styles.flex}>
+          {isIOS && statusBar && !disableDefaultStatusBarIOS ? (
+            <StatusBar {...statusBar} />
+          ) : null}
+          <GestureHandlerRootView style={styles.flex}>
+            <View style={[styles.backdropContainer]}>
+              <BackdropPressableComponent
+                accessibilityLabel={backdropAccessibilityLabel}
+                accessibilityHint={backdropAccessibilityHint}
+                style={styles.flex}
+                onPress={() => onRequestDismiss?.(DismissalSource.Backdrop)}
+              >
+                {renderBackdrop ? (
+                  renderBackdrop()
+                ) : (
+                  <View
+                    style={[styles.flex, { backgroundColor: backdropColor }]}
+                  />
+                )}
+              </BackdropPressableComponent>
             </View>
-          </ScrollContextResetter>
-        </GestureHandlerRootView>
-      </View>
+            <ScrollContextResetter>
+              <View
+                pointerEvents='box-none'
+                style={[styles.content, contentContainerStyle]}
+              >
+                {children}
+              </View>
+            </ScrollContextResetter>
+          </GestureHandlerRootView>
+        </View>
+      </AppContainerWrapper>
     </RNTModalView>
   );
 };


### PR DESCRIPTION
Please provide enough information so that others can review your pull request:

**Thanks for creating the package! It's clean and works great.**

## Motivation

While using react-native-multiple-modals, I realized that the React Native DevTools inspector couldn't target any Views inside it.

## Fix

Fix it by adding required AppContainer that the default React Native Modal component uses as well

## Testing

Tested in modal in our app:

| Before | After |
| --- | --- |
| ![Before](https://github.com/user-attachments/assets/643817ca-4496-459a-97d5-28e26f1ca537) | ![After](https://github.com/user-attachments/assets/c6a36fa9-2eb1-4570-9246-265e739c6855) |