### PR TITLE
Ensure modal size changes correctly when orientation changes

### DIFF
--- a/common/cpp/react/renderer/components/multiplemodals/RNTModalViewUtils.mm
+++ b/common/cpp/react/renderer/components/multiplemodals/RNTModalViewUtils.mm
@@ -9,17 +9,7 @@ namespace facebook::react {
 
 Size RNTModalViewSize(void)
 {
-    __block CGSize screenSize = RCTScreenSize();
-    
-    dispatch_sync(dispatch_get_main_queue(), ^{
-        RNTModalWindowHelper *windowHelper = [[RNTModalWindowHelper alloc] init];
-        UIInterfaceOrientation orientation = [windowHelper getWindowOrientation];
-        
-        if (UIInterfaceOrientationIsLandscape(orientation)) {
-            screenSize = CGSizeMake(screenSize.height, screenSize.width);
-        }
-    });
-    
+    CGSize screenSize = RCTScreenSize();
     return { screenSize.width, screenSize.height };
 }
 

--- a/ios/Library/RNTModalViewController/RNTModalViewController.h
+++ b/ios/Library/RNTModalViewController/RNTModalViewController.h
@@ -28,7 +28,6 @@
 @property(nonatomic, strong) ModalAnimation *inAnimation;
 @property(nonatomic, strong) ModalAnimation *outAnimation;
 @property(nonatomic, assign) CGRect lastBounds;
-@property(nonatomic, assign) BOOL shouldTrackRotationChange;
 
 @end
 

--- a/ios/Library/RNTModalViewController/RNTModalViewController.m
+++ b/ios/Library/RNTModalViewController/RNTModalViewController.m
@@ -14,7 +14,6 @@
     if (self) {
         self.reactSubviewContainer = [[UIView alloc] init];
         self.delegate = delegate;
-        self.shouldTrackRotationChange = NO;
     }
     return self;
 }
@@ -38,16 +37,10 @@
     [self setupReactSubview:self.reactSubviewContainer];
 }
 
-- (void)viewDidAppear:(BOOL)animated {
-    [self.inAnimation animate:self.reactSubviewContainer completion:^(BOOL finished) {
-        self.shouldTrackRotationChange = YES;
-    }];
-}
-
 - (void)viewDidLayoutSubviews
 {
     [super viewDidLayoutSubviews];
-    if (!CGRectEqualToRect(self.lastBounds, self.view.bounds) && self.shouldTrackRotationChange) {
+    if (!CGRectEqualToRect(self.lastBounds, self.view.bounds)) {
         [self.delegate boundsDidChange:self.view.bounds];
         self.lastBounds = self.view.bounds;
     }
@@ -67,7 +60,6 @@
     self.reactSubviewContainer = [self.reactSubviewContainer snapshotViewAfterScreenUpdates:NO];
     [prevReactSubviewContainer removeFromSuperview];
 
-    self.shouldTrackRotationChange = NO;
     [self setupReactSubview:self.reactSubviewContainer];
     [self.outAnimation prepareAnimation:self.reactSubviewContainer];
     [self.outAnimation animate:self.reactSubviewContainer completion:^(BOOL finished) {

--- a/ios/RNTModalShadowView.m
+++ b/ios/RNTModalShadowView.m
@@ -11,18 +11,7 @@
 {
     [super insertReactSubview:subview atIndex:atIndex];
     if ([subview isKindOfClass:[RCTShadowView class]]) {
-        dispatch_sync(dispatch_get_main_queue(), ^{
-            RNTModalWindowHelper *windowHelper = [[RNTModalWindowHelper alloc] init];
-            UIInterfaceOrientation orientation = [windowHelper getWindowOrientation];
-            
-            CGSize screenSize = RCTScreenSize();
-            
-            if (UIInterfaceOrientationIsPortrait(orientation)) {
-                ((RCTShadowView *)subview).size = screenSize;
-            } else {
-                ((RCTShadowView *)subview).size = CGSizeMake(screenSize.height, screenSize.width);
-            }
-        });
+        ((RCTShadowView *)subview).size = RCTScreenSize();
     }
 }
 


### PR DESCRIPTION
## Motivation

Users of our app (that had recently switched to react-native-multiple-modals) noticed that the modal had the wrong sizes in some cases:

1. When starting the app in landscape, the orientation was incorrect
2. When opening the modal after rotating, the orientation would also become incorrect

## Investigation/root cause

1. Right now, we call RCTScreenSize and invert the size if it's in landscape. This isn't needed and causes the initial dimensions to be inverted because [RCTScreenSize](https://github.com/facebook/react-native/blob/v0.82.0/packages/react-native/React/Base/RCTUtils.mm#L389) already takes into account the orientation
2. For unknown reasons, RNTModalViewController's `viewDidAppear` never seems to get called on Paper, which makes it so that `shouldTrackRotationChange` never gets set to true. This also seems not to be really needed and isn't used in the React Native equivalent [RCTModalHostViewController.m](https://github.com/facebook/react-native/blob/v0.81.4/packages/react-native/React/Fabric/Mounting/ComponentViews/Modal/RCTFabricModalHostViewController.mm#L28)

## Fix

1. Just call RCTScreenSize without processing the output, since it already accounts for screen orientation
2. Get rid of `shouldTrackRotationChange`

## Testing

**Note: I only tested on Paper since our app is on an old, non-Fabric RN version**

In the before version, the scrim doesn't cover the correct part of the screen because the shadow view width is incorrect.

| Before | After |
| ----- | ----- |
| ![Before](https://github.com/user-attachments/assets/b0d5f81a-acf8-4073-bd90-92f4928a58c3) | ![After](https://github.com/user-attachments/assets/0e41a0db-d79a-472e-a906-598f3bdaa405) |