### PR TITLE
feat(heightCalculation) calculate height with getRealSize

### DIFF
--- a/android/src/main/java/com/multiplemodals/library/ModalHostHelper.kt
+++ b/android/src/main/java/com/multiplemodals/library/ModalHostHelper.kt
@@ -16,31 +16,9 @@ internal object ModalHostHelper {
     fun getModalHostSize(context: Context, includeStatusBar: Boolean): Point {
         val wm = context.getSystemService(Context.WINDOW_SERVICE) as WindowManager
         val display = Assertions.assertNotNull(wm).defaultDisplay
-        // getCurrentSizeRange will return the min and max width and height that the window can be
-        display.getCurrentSizeRange(MIN_POINT, MAX_POINT)
-        // getSize will return the dimensions of the screen in its current orientation
-        display.getSize(SIZE_POINT)
-
-        val attrs = intArrayOf(R.attr.windowFullscreen)
-        val theme = context.theme
-        val ta = theme.obtainStyledAttributes(attrs)
-        val windowFullscreen = ta.getBoolean(0, false)
-
-        // We need to add the status bar height to the height if we have a fullscreen window,
-        // because Display.getCurrentSizeRange doesn't include it.
-        val resources = context.resources
-        val statusBarId = resources.getIdentifier("status_bar_height", "dimen", "android")
-        var statusBarHeight = 0
-        if ((windowFullscreen || includeStatusBar) && statusBarId > 0) {
-            statusBarHeight = resources.getDimension(statusBarId).toInt()
-        }
-
-        return if (SIZE_POINT.x < SIZE_POINT.y) {
-            // If we are vertical the width value comes from min width and height comes from max height
-            Point(MIN_POINT.x, MAX_POINT.y + statusBarHeight)
-        } else {
-            // If we are horizontal the width value comes from max width and height comes from min height
-            Point(MAX_POINT.x, MIN_POINT.y + statusBarHeight)
-        }
+        
+        display.getRealSize(SIZE_POINT)
+        
+        return SIZE_POINT
     }
 }


### PR DESCRIPTION
This PR simplifies the logic used to determine the screen dimensions for the Modal host on Android.

## Motivation
The previous implementation attempted to manually calculate the window size by combining getCurrentSizeRange, getSize, and a manually resolved status bar height.

This logic grew brittle across different Android manufacturers and OS versions.
Specifically, it led to inconsistencies where the bottom navigation bar (soft keys) was sometimes double-counted or excluded incorrectly, causing the Modal background to either fall short of the bottom edge or extend too far.
Manually resolving windowFullscreen themes and status_bar_height resources is often unreliable in modern edge-to-edge Android layouts.
The Solution:
I have replaced the complex calculation with display.getRealSize().

This method returns the actual raw pixel size of the display, including the system decorations (status bar and navigation bar).
This ensures the Modal always covers the entire physical screen, providing a consistent canvas.
Recommendation for Consumers:
With this change, the Modal will span the full screen. To handle padding for the Status Bar and Bottom Navigation Bar, consumers should rely on standard libraries like react-native-safe-area-context within their JavaScript/React components. This delegates insets handling to the UI layer where it belongs, rather than hardcoding assumptions in the native module layer.

Changes
Removed manual status bar height calculation and getCurrentSizeRange logic.
Implemented display.getRealSize(SIZE_POINT) to reliably get the full physical screen dimensions.
Test Plan
Open the app on an Android device with a software navigation bar (e.g., Pixel).
Open a Modal.
Verify the modal background covers the entire screen, including behind the status bar and navigation bar.
Verify on a device with gesture navigation enabled.


![WhatsApp Image 2026-01-23 at 14 33 18](https://github.com/user-attachments/assets/7d9ec249-63a4-40c2-b726-886adc119674)


