### PR TITLE
feat(hideBackdrop) implement feature to hide the backdrop with showBa…

### DIFF
--- a/src/ModalView.tsx
+++ b/src/ModalView.tsx
@@ -24,6 +24,7 @@ export const ModalView: FC<ModalViewProps> = ({
   onRequestDismiss,
   contentContainerStyle,
   statusBar,
+  showBackdrop = true,
   BackdropPressableComponent = Pressable,
   backdropColor = defaultBackdropColor,
   disableDefaultStatusBarIOS = false,
@@ -44,22 +45,24 @@ export const ModalView: FC<ModalViewProps> = ({
             <StatusBar {...statusBar} />
           ) : null}
           <GestureHandlerRootView style={styles.flex}>
-            <View style={[styles.backdropContainer]}>
-              <BackdropPressableComponent
-                accessibilityLabel={backdropAccessibilityLabel}
-                accessibilityHint={backdropAccessibilityHint}
-                style={styles.flex}
-                onPress={() => onRequestDismiss?.(DismissalSource.Backdrop)}
-              >
-                {renderBackdrop ? (
-                  renderBackdrop()
-                ) : (
-                  <View
-                    style={[styles.flex, { backgroundColor: backdropColor }]}
-                  />
-                )}
-              </BackdropPressableComponent>
-            </View>
+            {showBackdrop && (
+              <View style={[styles.backdropContainer]}>
+                <BackdropPressableComponent
+                  accessibilityLabel={backdropAccessibilityLabel}
+                  accessibilityHint={backdropAccessibilityHint}
+                  style={styles.flex}
+                  onPress={() => onRequestDismiss?.(DismissalSource.Backdrop)}
+                >
+                  {renderBackdrop ? (
+                    renderBackdrop()
+                  ) : (
+                    <View
+                      style={[styles.flex, { backgroundColor: backdropColor }]}
+                    />
+                  )}
+                </BackdropPressableComponent>
+              </View>
+            )}
             <ScrollContextResetter>
               <View
                 pointerEvents='box-none'

--- a/src/ModalView.web.tsx
+++ b/src/ModalView.web.tsx
@@ -30,6 +30,7 @@ export const ModalView: FC<ModalViewWebProps> = ({
   renderBackdrop,
   onRequestDismiss,
   contentContainerStyle,
+  showBackdrop = true,
   BackdropPressableComponent = Pressable,
   backdropColor = defaultBackdropColor,
   animationType = 'none',
@@ -57,22 +58,24 @@ export const ModalView: FC<ModalViewWebProps> = ({
   }, [animationType, modalIsOpen]);
 
   return createPortal(
-    <View style={[styles.backdropContainer]}>
-      <BackdropPressableComponent
-        accessibilityLabel={backdropAccessibilityLabel}
-        accessibilityHint={backdropAccessibilityHint}
-        style={[
-          styles.backdropPressable,
-          !isBackdropVisible && styles.backdropHidden,
-        ]}
-        onPress={() => onRequestDismiss?.(DismissalSource.Backdrop)}
-      >
-        {renderBackdrop ? (
-          renderBackdrop()
-        ) : (
-          <View style={[styles.flex, { backgroundColor: backdropColor }]} />
-        )}
-      </BackdropPressableComponent>
+    <View style={[showBackdrop && styles.backdropContainer]}>
+      {showBackdrop && (
+        <BackdropPressableComponent
+          accessibilityLabel={backdropAccessibilityLabel}
+          accessibilityHint={backdropAccessibilityHint}
+          style={[
+            styles.backdropPressable,
+            !isBackdropVisible && styles.backdropHidden,
+          ]}
+          onPress={() => onRequestDismiss?.(DismissalSource.Backdrop)}
+        >
+          {renderBackdrop ? (
+            renderBackdrop()
+          ) : (
+            <View style={[styles.flex, { backgroundColor: backdropColor }]} />
+          )}
+        </BackdropPressableComponent>
+      )}
 
       <View
         role='dialog'

--- a/src/types.ts
+++ b/src/types.ts
@@ -66,6 +66,12 @@ export type ModalViewProps = {
   animationType?: 'none' | 'fade' | 'slide';
 
   /**
+   * Whether to show the backdrop behind the modal.
+   * Defaults to true.
+   */
+  showBackdrop?: boolean;
+
+  /**
    * @deprecated Use `statusBar.translucent` instead.
    */
   statusBarTranslucent?: boolean;


### PR DESCRIPTION
This PR introduces a new prop _showBackdrop_ to the ModalView component. This boolean prop allows consumers to control whether the modal's backdrop should be rendered. The feature is set to true by default which makes it backwards compatible.

Motivation:
There are use cases where a developer might want to display a modal without the visual dimming or the blocking overlay of a backdrop (e.g., custom floating overlays, non-blocking tooltips, or simply managing the backdrop manually). This prop provides that flexibility.