### PR TITLE
fix: iOS modal freeze when animationType prop is set

### DIFF
--- a/ios/Library/RNTModalViewController/RNTModalViewController.m
+++ b/ios/Library/RNTModalViewController/RNTModalViewController.m
@@ -14,6 +14,9 @@
     if (self) {
         self.reactSubviewContainer = [[UIView alloc] init];
         self.delegate = delegate;
+        ModalAnimation *defaultAnimation = [[ModalAnimation alloc] init];
+        self.inAnimation = defaultAnimation;
+        self.outAnimation = defaultAnimation;
     }
     return self;
 }
@@ -35,6 +38,11 @@
     
     [self.inAnimation prepareAnimation:self.reactSubviewContainer];
     [self setupReactSubview:self.reactSubviewContainer];
+}
+
+- (void)viewDidAppear:(BOOL)animated {
+    [super viewDidAppear:animated];
+    [self.inAnimation animate:self.reactSubviewContainer completion:nil];
 }
 
 - (void)viewDidLayoutSubviews


### PR DESCRIPTION
## Motivation

I've encountered an issue with modal freeze when animationType was provided, reported here: https://github.com/paufau/react-native-multiple-modals/issues/64
I've tested the patch provided by @khanjandobariya and simplified it a little bit. 
Let me know what you think!

## Summary

When `animationType` is set to `fade` or `slide`, the modal content freezes and becomes invisible on iOS. This happens because `prepareAnimation:` is called in `viewDidLoad`, but `animate:` is never called to transition to the visible state.

## Changes

- Initialize default animations in `initWithDelegate:` ensures `inAnimation`/`outAnimation` are never nil between init and `setAnimationType:`
- Add `viewDidAppear:` calls `[self.inAnimation animate:...]`: to actually run the entrance animation after the view is on screen

## Testing

Tested on every modal in [react-native-multiple-modals-examples](https://github.com/paufau/react-native-multiple-modals-examples) using the patch below.

## Simplified Patch

```
diff --git a/node_modules/react-native-multiple-modals/ios/Library/RNTModalViewController/RNTModalViewController.m b/node_modules/react-native-multiple-modals/ios/Library/RNTModalViewController/RNTModalViewController.m
index a695eeb..d581919 100644
--- a/node_modules/react-native-multiple-modals/ios/Library/RNTModalViewController/RNTModalViewController.m
+++ b/node_modules/react-native-multiple-modals/ios/Library/RNTModalViewController/RNTModalViewController.m
@@ -14,6 +14,9 @@ - (instancetype)initWithDelegate:(id<RNTModalViewControllerDelegate>)delegate {
     if (self) {
         self.reactSubviewContainer = [[UIView alloc] init];
         self.delegate = delegate;
+        ModalAnimation *defaultAnimation = [[ModalAnimation alloc] init];
+        self.inAnimation = defaultAnimation;
+        self.outAnimation = defaultAnimation;
     }
     return self;
 }
@@ -37,6 +40,11 @@ - (void)viewDidLoad {
     [self setupReactSubview:self.reactSubviewContainer];
 }
 
+- (void)viewDidAppear:(BOOL)animated {
+    [super viewDidAppear:animated];
+    [self.inAnimation animate:self.reactSubviewContainer completion:nil];
+}
+
 - (void)viewDidLayoutSubviews
 {
     [super viewDidLayoutSubviews];

```