### PR TITLE
fix: lazy import AppContainer to prevent crash in production Android builds

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -64,6 +64,7 @@ android {
     minSdkVersion getExtOrIntegerDefault("minSdkVersion")
     targetSdkVersion getExtOrIntegerDefault("targetSdkVersion")
     buildConfigField("boolean", "IS_NEW_ARCHITECTURE_ENABLED", isNewArchitectureEnabled().toString())
+    consumerProguardFiles "consumer-proguard-rules.pro"
   }
 
   sourceSets {

--- a/android/consumer-proguard-rules.pro
+++ b/android/consumer-proguard-rules.pro
@@ -1,0 +1,5 @@
+# react-native-multiple-modals
+# Keep all classes in the library's package to prevent R8/ProGuard
+# from stripping or renaming them during minification.
+-keep class com.multiplemodals.** { *; }
+-keepnames class com.multiplemodals.** { *; }

--- a/src/LayoutInspectorProvider.tsx
+++ b/src/LayoutInspectorProvider.tsx
@@ -1,6 +1,5 @@
 import { FC, PropsWithChildren, useContext } from 'react';
 
-import AppContainer from 'react-native/Libraries/ReactNative/AppContainer';
 import { RootTagContext } from 'react-native/Libraries/ReactNative/RootTag';
 
 // Wrap the children in AppContainer so the React Native inspector works
@@ -15,6 +14,12 @@ export const LayoutInspectorProvider: FC<PropsWithChildren> = ({
   if (!__DEV__) {
     return children;
   }
+
+  // Lazy import to avoid bundling AppContainer in production builds.
+  // AppContainer is an internal React Native module that may not be
+  // available in production builds on Android, causing crashes.
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  const AppContainer = require('react-native/Libraries/ReactNative/AppContainer').default;
 
   return <AppContainer rootTag={rootTag}>{children}</AppContainer>;
 };


### PR DESCRIPTION
## Description

Fixes #65 — App crashes on Android production builds (`.apk`) when opening a modal.

### Root Cause

There are **two separate issues** causing crashes in production Android builds:

#### 1. JavaScript: Static import of internal React Native module

`LayoutInspectorProvider.tsx` statically imports `AppContainer` from React Native internals:

```tsx
import AppContainer from 'react-native/Libraries/ReactNative/AppContainer';
```

Even though the `__DEV__` check prevents `AppContainer` from being **rendered** in production, the **import is always executed** at the top level. In production Android builds, the Metro bundler may strip or optimize internal React Native modules, causing the import to fail and crash the app.

#### 2. Native Android: R8/ProGuard stripping native classes

The library does not include `consumerProguardFiles`, so R8/ProGuard strips the native `com.multiplemodals.RNTModalView` class during minification. This causes a `ClassNotFoundException` at runtime when the modal is opened:

```
java.lang.ClassNotFoundException: com.multiplemodals.RNTModalView
```

Currently, every consumer must manually add ProGuard keep rules to their app, which is error-prone and undocumented.

---

### Fix

#### 1. Lazy import of `AppContainer` (`src/LayoutInspectorProvider.tsx`)

Changed the `AppContainer` import from a static top-level import to a **lazy `require()` inside the `__DEV__` block**. This ensures the internal module is only resolved in development mode, and is completely excluded from production bundles.

**Before:**
```tsx
import AppContainer from 'react-native/Libraries/ReactNative/AppContainer';

export const LayoutInspectorProvider = ({ children }) => {
  const rootTag = useContext(RootTagContext);
  if (!__DEV__) return children;
  return <AppContainer rootTag={rootTag}>{children}</AppContainer>;
};
```

**After:**
```tsx
export const LayoutInspectorProvider = ({ children }) => {
  const rootTag = useContext(RootTagContext);
  if (!__DEV__) return children;

  const AppContainer = require('react-native/Libraries/ReactNative/AppContainer').default;
  return <AppContainer rootTag={rootTag}>{children}</AppContainer>;
};
```

#### 2. Consumer ProGuard rules (`android/`)

Added a `consumer-proguard-rules.pro` file and referenced it in `build.gradle` via `consumerProguardFiles`. This ensures the necessary keep rules are **automatically applied** to any app that consumes this library — no manual ProGuard configuration needed by consumers.

**New file `android/consumer-proguard-rules.pro`:**
```pro
-keep class com.multiplemodals.** { *; }
-keepnames class com.multiplemodals.** { *; }
```

**`android/build.gradle` change:**
```diff
  defaultConfig {
    ...
+   consumerProguardFiles "consumer-proguard-rules.pro"
  }
```

### Testing

- ✅ Development mode: Inspector still works correctly via `AppContainer`
- ✅ Production Android build (`.apk`): No crash when opening modals
- ✅ ProGuard rules automatically applied — no manual configuration needed by consumers
- ✅ Tested locally with `yarn patch` applying all three changes, confirmed working on a real device